### PR TITLE
Add AtomAlpaca link to index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,8 @@
 * cclvi: [https://cclvi.cc/](https://cclvi.cc/)
 * hkbin: [https://www.hkbinbin.fun/](https://www.hkbinbin.fun/)
 * Munan: [https://sxsxno.github.io/](https://sxsxno.github.io/)
+* AtomAlpaca: [https://www.atal.moe/](https://www.atal.moe/)
+
 
 
 <!-- ![JEQG0zJ.png](https://iili.io/JEQG0zJ.png) -->


### PR DESCRIPTION
Added a new link for AtomAlpaca to the documentation.